### PR TITLE
Adding HOOBS Certified and HOOBS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![npm](https://badgen.net/npm/dt/homebridge-skybell)](https://www.npmjs.com/package/homebridge-skybell)
 [![npm](https://badgen.net/npm/dw/homebridge-skybell)](https://www.npmjs.com/package/homebridge-skybell)
 [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
+[![certified-hoobs-plugin](https://badgen.net/badge/HOOBS/Certified/yellow)](https://plugins.hoobs.org) [![hoobs-support](https://badgen.net/badge/HOOBS/Support/yellow)](https://support.hoobs.org)
+
 
 SkyBell HD Wi-Fi video doorbell plugin for [Homebridge](https://github.com/nfarina/homebridge).
 


### PR DESCRIPTION
Hello @thoukydides 

We like to inform you that we have certified your Plugin directly for HOOBS as we no longer fork the plugin to certify it.

Your Plugin is set to automatically certify the Latest version you push to npm.

**Heres the Plugin site of your Plugin:**
https://plugins.hoobs.org/plugin/homebridge-skybell

_HOOBS Tab - shows the HOOBS customised Readme
Homebridge Tab - shows your Readme on npm_

Users can also write reviews there and we plan to extend it with an Plugin based forum.

All support will be done by HOOBS, and you can direct any HOOBS Users to our Support site:
http://support.hoobs.org

We will check if its an Issue related to HOOBS or an issue with the Plugin itself. If the second is the case we will contact you via issues on your GitHub repo.

We added two badges to your readme:

[![certified-hoobs-plugin](https://badgen.net/badge/HOOBS/Certified/yellow)](https://plugins.hoobs.org) [![hoobs-support](https://badgen.net/badge/HOOBS/Support/yellow)](https://support.hoobs.org)

Regards

Bobby @hoobs-org
